### PR TITLE
Throw an exception in 'useMapInstance' if no provider for the MapContext is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## UNRELEASED
+
+- Changed: **BREAKING** `useMapInstance` will no longer return null values and throw an exception if no provider for `MapContext` was found.
+- Changed: **BREAKING** `useEvents` must be provided with a non-null value.
+
 ## 0.8.3
 
 - Added: `CircleMarker` component export

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/react-hooks": "^3.2.1",
+    "@testing-library/react-hooks": "^3.4.1",
     "@types/eslint": "^7.2.0",
     "@types/eslint-plugin-prettier": "^3.1.0",
     "@types/geojson": "^7946.0.7",

--- a/src/utils/useAddToMapInstance.ts
+++ b/src/utils/useAddToMapInstance.ts
@@ -1,7 +1,7 @@
 import { Map } from 'leaflet'
 import { useEffect, useState } from 'react'
-import useMapInstance from './useMapInstance'
 import { AllLeafletInstances } from '../types'
+import useMapInstance from './useMapInstance'
 
 export default <T extends AllLeafletInstances>(
   instance: T,
@@ -16,11 +16,7 @@ export default <T extends AllLeafletInstances>(
   // Cleanup
   useEffect(
     () => () => {
-      if (
-        mapInstance &&
-        componentInstance &&
-        mapInstance.hasLayer(componentInstance)
-      ) {
+      if (componentInstance && mapInstance.hasLayer(componentInstance)) {
         componentInstance.removeFrom(mapInstance)
       }
     },
@@ -29,7 +25,7 @@ export default <T extends AllLeafletInstances>(
 
   // Add to map instance
   useEffect(() => {
-    if (mapInstance && !componentInstance) {
+    if (!componentInstance) {
       setComponentInstance(
         customAdd
           ? customAdd(instance, mapInstance)

--- a/src/utils/useMapEvents.ts
+++ b/src/utils/useMapEvents.ts
@@ -1,6 +1,6 @@
-import { LeafletEventHandlerFnMap, Map } from 'leaflet'
-import useMapInstance from './useMapInstance'
+import { LeafletEventHandlerFnMap } from 'leaflet'
 import useEvents from './useEvents'
+import useMapInstance from './useMapInstance'
 
 /**
  * Uses useEvents hook with mapInstance
@@ -8,7 +8,7 @@ import useEvents from './useEvents'
  */
 const useMapEvents = (events?: LeafletEventHandlerFnMap) => {
   const mapInstance = useMapInstance()
-  useEvents<Map>(mapInstance, events)
+  useEvents(mapInstance, events)
 }
 
 export default useMapEvents

--- a/src/utils/useMapInstance.test.tsx
+++ b/src/utils/useMapInstance.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { Map } from 'leaflet'
+import React from 'react'
+import MapContext from '../MapContext'
+import useMapInstance from './useMapInstance'
+
+describe('useMapInstance', () => {
+  it('should use the map instance', () => {
+    const mockInstance = ({ foo: 'bar' } as unknown) as Map
+    const wrapper: React.FC = ({ children }) => (
+      <MapContext.Provider
+        value={{
+          mapInstance: mockInstance,
+        }}
+      >
+        {children}
+      </MapContext.Provider>
+    )
+
+    const { result } = renderHook(() => useMapInstance(), { wrapper })
+    expect(result.current).toEqual(mockInstance)
+  })
+
+  it("should throw an exception if the provider doesn't exist", () => {
+    const { result } = renderHook(() => useMapInstance())
+    expect(result.error).toBeDefined()
+  })
+})

--- a/src/utils/useMapInstance.ts
+++ b/src/utils/useMapInstance.ts
@@ -1,8 +1,14 @@
-import React from 'react'
+import { useContext } from 'react'
 import MapContext from '../MapContext'
 
 const useMapInstance = () => {
-  const { mapInstance } = React.useContext(MapContext)
+  const { mapInstance } = useContext(MapContext)
+
+  if (!mapInstance) {
+    throw new Error(
+      'Unable to retrieve map instance, no provider could be found for the MapContext.',
+    )
+  }
 
   return mapInstance
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,7 +1343,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/react-hooks@^3.2.1":
+"@testing-library/react-hooks@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
   integrity sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==


### PR DESCRIPTION
This removes the need to check the value returned by `useMapInstance` for null values, reducing the amount of code needed to use this hook.